### PR TITLE
12.0 mixin to prevent fiscal child links

### DIFF
--- a/fiscal_company_account/models/account_account.py
+++ b/fiscal_company_account/models/account_account.py
@@ -8,4 +8,8 @@ from odoo import models
 
 class AccountAccount(models.Model):
     _name = "account.account"
-    _inherit = ["account.account", "include.fiscal.company.search.mixin"]
+    _inherit = [
+        "account.account",
+        "include.fiscal.company.search.mixin",
+        "fiscal.child.check.mixin",
+    ]

--- a/fiscal_company_account/models/account_tax.py
+++ b/fiscal_company_account/models/account_tax.py
@@ -8,11 +8,19 @@ from odoo import api, models
 
 class AccountTax(models.Model):
     _name = "account.tax"
-    _inherit = ["account.tax", "include.fiscal.company.search.mixin"]
+    _inherit = [
+        "account.tax",
+        "include.fiscal.company.search.mixin",
+        "fiscal.child.check.mixin",
+    ]
 
-    # TODO, document this function
     @api.multi
     def filtered(self, func):
+        # a lot of function in Odoo are filtering taxes by the current company
+        # for exemple in 'addons/account/models/account_invoice.py#L1809'
+        # In our CAE case, we replace the current company by the fiscal one.
+
+        # TODO, improve that ugly code.
         if callable(func) and func.__code__.co_names == ("company_id",):
             company = self.env.user.company_id.fiscal_company_id
             return super().filtered(lambda x: x.company_id == company)

--- a/fiscal_company_base/models/__init__.py
+++ b/fiscal_company_base/models/__init__.py
@@ -1,3 +1,4 @@
+from . import fiscal_child_check_mixin
 from . import fiscal_mother_check_mixin
 from . import include_fiscal_company_search_mixin
 from . import res_company

--- a/fiscal_company_base/models/fiscal_child_check_mixin.py
+++ b/fiscal_company_base/models/fiscal_child_check_mixin.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2018 - Today: GRAP (http://www.grap.coop)
+# Copyright (C) 2021 - Today: GRAP (http://www.grap.coop)
 # @author: Sylvain LE GAL (https://twitter.com/legalsylvain)
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
@@ -7,24 +7,24 @@ from odoo import _, api, models
 from odoo.exceptions import ValidationError
 
 
-class FiscalMotherCheckMixin(models.AbstractModel):
+class FiscalChildCheckMixin(models.AbstractModel):
     """This abstract block the possibility for a model to have
-    items linked to a fiscal mother company.
+    items linked to a fiscal child company.
     Note that you can only inherit from this abstract, if the current model
     has ```company_id``` and ```name``` fields defined.
     """
 
-    _name = "fiscal.mother.check.mixin"
-    _description = "Fiscal Mother Check Mixin"
+    _name = "fiscal.child.check.mixin"
+    _description = "Fiscal Child Check Mixin"
 
     @api.constrains("company_id")
     def _check_fiscal_child_company_id(self):
-        bad_items = self.filtered(lambda x: x.company_id.fiscal_type == "fiscal_mother")
+        bad_items = self.filtered(lambda x: x.company_id.fiscal_type == "fiscal_child")
         if bad_items:
             raise ValidationError(
                 _(
                     "You can't affect the item(s) %s to a Fiscal"
-                    " Mother company.\n\n"
+                    " Child company.\n\n"
                     " (model '%s')"
                 )
                 % (",".join([x.name for x in bad_items]), self._name)


### PR DESCRIPTION
 [ADD] new mixin to prevent link to fiscal child and use it for account.account and account.tax.
[FIX] ir.rule to make the error message more understandable