### PR TITLE
[FIX] tax filtering by company_id should be correctly overloaded regardless syntax. Fix error of invoice created by pos.order without taxes.

### DIFF
--- a/fiscal_company_account/models/account_tax.py
+++ b/fiscal_company_account/models/account_tax.py
@@ -21,7 +21,7 @@ class AccountTax(models.Model):
         # In our CAE case, we replace the current company by the fiscal one.
 
         # TODO, improve that ugly code.
-        if callable(func) and func.__code__.co_names == ("company_id",):
+        if callable(func) and "company_id" in func.__code__.co_names:
             company = self.env.user.company_id.fiscal_company_id
             return super().filtered(lambda x: x.company_id == company)
         return super().filtered(func)

--- a/fiscal_company_account/readme/DEVELOP.rst
+++ b/fiscal_company_account/readme/DEVELOP.rst
@@ -1,0 +1,9 @@
+* For the migration to V>12, take care of the tax.filtered occurences in
+  Odoo and OCA modules.
+  There are a lot of ``filtered(lambda x: x.company_id == current_company)``
+  in Odoo. The module ``fiscal_company_account`` alter the behaviour of the function
+  ``filtered`` of the ``account.tax`` module, to filter on the mother fiscal company.
+  However, the changes is imperfect, and multiple filters (company and not company filters)
+  will fail.
+  During migration, please run:
+  ``rgrep "tax.*filtered.*company_id"``

--- a/fiscal_company_account/tests/__init__.py
+++ b/fiscal_company_account/tests/__init__.py
@@ -1,2 +1,3 @@
+from . import test_tax_filtered
 from . import test_decorator
 from . import test_propagate_properties

--- a/fiscal_company_account/tests/test_tax_filtered.py
+++ b/fiscal_company_account/tests/test_tax_filtered.py
@@ -1,0 +1,85 @@
+# Copyright (C) 2021 - Today: GRAP (http://www.grap.coop)
+# @author Sylvain LE GAL (https://twitter.com/legalsylvain)
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+from odoo.tests.common import TransactionCase
+
+
+class TestTaxFiltered(TransactionCase):
+    """Tests for Account Fiscal Company Module (Tax filter)"""
+
+    def setUp(self):
+        super().setUp()
+        self.taxes = self.env.ref("fiscal_company_account.sale_tax_20") | self.env.ref(
+            "fiscal_company_account.purchase_tax_20"
+        )
+        self.child_company = self.env.ref("fiscal_company_base.company_fiscal_child_1")
+        self.mother_company = self.env.ref("fiscal_company_base.company_fiscal_mother")
+
+    # Test Section
+    def test_01_filter_company(self):
+        child_company = self.child_company
+
+        for current_company in [self.child_company, self.mother_company]:
+            self.env.user.company_id = current_company
+
+            # Check Syntax 1
+            filtered_taxes = self.taxes.filtered(
+                lambda x: x.company_id == child_company
+            )
+            self.assertEqual(
+                len(filtered_taxes),
+                2,
+                "Filtering taxes by child company should not filter. (syntax 1)",
+            )
+
+            # Check Syntax 2
+            filtered_taxes = self.taxes.filtered(
+                lambda x: x.company_id.id == child_company.id
+            )
+            self.assertEqual(
+                len(filtered_taxes),
+                2,
+                "Filtering taxes by child company should not filter. (syntax 2)",
+            )
+
+            # Check Syntax 3
+            filtered_taxes = self.taxes.filtered(
+                lambda x: x.company_id.id == self.child_company.id
+            )
+            self.assertEqual(
+                len(filtered_taxes),
+                2,
+                "Filtering taxes by child company should not filter. (syntax 2)",
+            )
+
+            # Check No Regression (no filter)
+            filtered_taxes = self.taxes.filtered(lambda x: "20" in x.name)
+            self.assertEqual(
+                len(filtered_taxes), 2, "Filtering taxes by name should worker (1/3"
+            )
+
+            # Check No Regression (partial filter)
+            filtered_taxes = self.taxes.filtered(lambda x: "Purchase" in x.name)
+            self.assertEqual(
+                len(filtered_taxes), 1, "Filtering taxes by name should worker (2/3"
+            )
+
+            # Check No Regression (filter)
+            filtered_taxes = self.taxes.filtered(lambda x: "99" in x.name)
+            self.assertEqual(
+                len(filtered_taxes), 0, "Filtering taxes by name should worker (3/3"
+            )
+
+    def test_that_should_fail(self):
+        # we test multiple filter in the same time.
+        # The non company condition will not be applyed (and should be).
+        # It is a limitation of the current implementation.
+        # See details in DEVELOP.rst file.
+        self.env.user.company_id = self.mother_company
+        # the result should be 1, but it will return 2
+
+        filtered_taxes = self.taxes.filtered(
+            lambda x: x.company_id.id == self.child_company.id and "Purchase" in x.name
+        )
+        self.assertEqual(len(filtered_taxes), 2)


### PR DESCRIPTION
Ticket : apps/deck/#/board/144/card/1863
