### PR TITLE
[FIX] fiscal_company_account / base : don't alter filtered function for the account.tax model in the context of /fiscal_child_check_mixin

### DIFF
--- a/fiscal_company_account/models/account_tax.py
+++ b/fiscal_company_account/models/account_tax.py
@@ -21,7 +21,11 @@ class AccountTax(models.Model):
         # In our CAE case, we replace the current company by the fiscal one.
 
         # TODO, improve that ugly code.
-        if callable(func) and "company_id" in func.__code__.co_names:
+        if (
+            not self.env.context.get("dont_change_filter", False)
+            and callable(func)
+            and "company_id" in func.__code__.co_names
+        ):
             company = self.env.user.company_id.fiscal_company_id
             return super().filtered(lambda x: x.company_id == company)
         return super().filtered(func)

--- a/fiscal_company_base/models/fiscal_child_check_mixin.py
+++ b/fiscal_company_base/models/fiscal_child_check_mixin.py
@@ -19,7 +19,9 @@ class FiscalChildCheckMixin(models.AbstractModel):
 
     @api.constrains("company_id")
     def _check_fiscal_child_company_id(self):
-        bad_items = self.filtered(lambda x: x.company_id.fiscal_type == "fiscal_child")
+        bad_items = self.with_context(dont_change_filter=True).filtered(
+            lambda x: x.company_id.fiscal_type == "fiscal_child"
+        )
         if bad_items:
             raise ValidationError(
                 _(


### PR DESCRIPTION
refactor introduced here https://github.com/odoo-cae/odoo-addons-cae/pull/36 is correct. But changing filter should not done in the context of fiscal_check_mixin.

Fix : apps/deck/#/board/144/card/1879

